### PR TITLE
XPath eval and dump to string

### DIFF
--- a/c14n.cabal
+++ b/c14n.cabal
@@ -1,4 +1,4 @@
-cabal-version: 1.12
+cabal-version: 2.2
 
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --
@@ -32,6 +32,7 @@ library
   hs-source-dirs:
       src
   ghc-options: -W
+  cc-options: -std=c99 -Wno-builtin-declaration-mismatch
   c-sources:
       cbits/libxml.c
   extra-libraries:
@@ -44,4 +45,5 @@ library
     , containers
     , inline-c
     , template-haskell
+    , vector
   default-language: Haskell2010

--- a/c14n.cabal
+++ b/c14n.cabal
@@ -25,6 +25,7 @@ source-repository head
 library
   exposed-modules:
       Text.XML.C14N
+      Text.XML.C14N.Internal
       Text.XML.C14N.LibXML
   other-modules:
       Paths_c14n
@@ -40,4 +41,7 @@ library
   build-depends:
       base >=4.8 && <5
     , bytestring >=0.9 && <0.11
+    , containers
+    , inline-c
+    , template-haskell
   default-language: Haskell2010

--- a/c14n.cabal
+++ b/c14n.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 1.12
 
 -- This file has been generated from package.yaml by hpack version 0.34.4.
 --

--- a/package.yaml
+++ b/package.yaml
@@ -20,6 +20,9 @@ extra-libraries:
 dependencies:
 - base >= 4.8 && < 5
 - bytestring >= 0.9 && < 0.11
+- inline-c
+- template-haskell
+- containers
 
 library:
     source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -23,9 +23,14 @@ dependencies:
 - inline-c
 - template-haskell
 - containers
+- vector
 
 library:
     source-dirs: src
     c-sources: cbits/*.c
     ghc-options:
     - -W
+    cc-options:
+    # enable `strdup`:
+    - -std=c99
+    - -Wno-builtin-declaration-mismatch

--- a/src/Text/XML/C14N.hs
+++ b/src/Text/XML/C14N.hs
@@ -48,7 +48,6 @@ module Text.XML.C14N (
     evalXPath'each,
     evalXPath,
     evalXPathArr,
-    testLibxml,
 
     nodePathIdx,
     nodeByPath,
@@ -69,7 +68,6 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Vector (Vector)
-import qualified Data.Vector as V
 
 import Text.XML.C14N.LibXML
 

--- a/src/Text/XML/C14N.hs
+++ b/src/Text/XML/C14N.hs
@@ -52,10 +52,12 @@ module Text.XML.C14N (
     nodePathIdx,
     nodeByPath,
     dumpNode ,
+    nodeFirstChild,
     nodeChildren,
     nodeNext,
     nodeName,
-    isNullPtr 
+    isNullPtr,
+    nodePositionInNamesakes
 ) where 
 
 --------------------------------------------------------------------------------

--- a/src/Text/XML/C14N/Internal.hs
+++ b/src/Text/XML/C14N/Internal.hs
@@ -12,19 +12,32 @@ import           Language.C.Inline.Context
 import qualified Language.C.Types as CT
 
 
+-- | XML documents
+data LibXMLDoc
+
+
+-- | XML node
+data LibXMLNode
+
+
 -- | XML node sets
 data LibXMLNodeSet
+
 
 -- | XML Buffer
 data LibXMLBuffer
 
+
 xmlCtx :: C.Context
-xmlCtx = baseCtx <> ctx
+xmlCtx = baseCtx <> bsCtx <> ctx
   where
     ctx = mempty { ctxTypesTable = xmlTypesTable }
 
+
 xmlTypesTable :: Map.Map CT.TypeSpecifier TH.TypeQ
 xmlTypesTable = Map.fromList
-    [ (CT.TypeName "xmlBuffer",  [t| LibXMLBuffer  |])
+    [ (CT.TypeName "xmlDoc",     [t| LibXMLDoc     |])
+    , (CT.TypeName "xmlNode",    [t| LibXMLNode    |])
     , (CT.TypeName "xmlNodeSet", [t| LibXMLNodeSet |])
+    , (CT.TypeName "xmlBuffer",  [t| LibXMLBuffer  |])
     ]

--- a/src/Text/XML/C14N/Internal.hs
+++ b/src/Text/XML/C14N/Internal.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Text.XML.C14N.Internal where
+
+import qualified Data.Map as Map
+import           Data.Monoid ((<>), mempty)
+import qualified Language.Haskell.TH as TH
+
+import qualified Language.C.Inline as C
+import           Language.C.Inline.Context
+import qualified Language.C.Types as CT
+
+
+-- | XML node sets
+data LibXMLNodeSet
+
+-- | XML Buffer
+data LibXMLBuffer
+
+xmlCtx :: C.Context
+xmlCtx = baseCtx <> ctx
+  where
+    ctx = mempty { ctxTypesTable = xmlTypesTable }
+
+xmlTypesTable :: Map.Map CT.TypeSpecifier TH.TypeQ
+xmlTypesTable = Map.fromList
+    [ (CT.TypeName "xmlBuffer",  [t| LibXMLBuffer  |])
+    , (CT.TypeName "xmlNodeSet", [t| LibXMLNodeSet |])
+    ]

--- a/src/Text/XML/C14N/LibXML.hsc
+++ b/src/Text/XML/C14N/LibXML.hsc
@@ -46,6 +46,7 @@ module Text.XML.C14N.LibXML (
     xml_opt_ignore_env,
     xml_opt_big_lines,
     xmlReadMemory,
+    htmlReadMemory,
     xmlFreeDoc,
 
     -- * XML canonicalisation
@@ -231,6 +232,15 @@ foreign import ccall unsafe "libxml/parser.h xmlReadMemory"
                   -> CString 
                   -> CInt 
                   -> IO (Ptr LibXMLDoc)
+
+-- | Parses an XML document from a textual representation held in memory.
+foreign import ccall unsafe "libxml/parser.h htmlReadMemory"
+    htmlReadMemory :: CString   -- ^ buffer
+                   -> CInt      -- ^ size of document
+                   -> CString   -- ^ URL
+                   -> CString   -- ^ encoding
+                   -> CInt      -- ^ options
+                   -> IO (Ptr LibXMLDoc)
 
 -- | Writes the canonicalised representation of an XML document to memory.
 foreign import ccall unsafe "libxml/c14n.h xmlC14NDocDumpMemory"

--- a/src/Text/XML/C14N/LibXML.hsc
+++ b/src/Text/XML/C14N/LibXML.hsc
@@ -75,8 +75,6 @@ module Text.XML.C14N.LibXML (
     xmlNodeSetDumpArr,
     xmlNodeSetMap,
 
-    testLibxml,
-
     nodePathIdx ,
     nodeByPath ,
     dumpNode ,


### PR DESCRIPTION
Additional bindings for eval XPath and output result node set to `ByteString`.

`c14n` package output result in XML canonical form with buggy output (strips node attributes and texts),
like this:

`<div><x1/><x2/></div>`

instead of

`<div id="a1">txt1<x1/>txt2<x2/>txt3</div>`

In this PR I introduce `evalXPath` function which evaluate XPath and then dump node set to `ByteString`.

So we can write: `evalXPath "<div id="a1">txt1<x1/>txt2<x2/>txt3</div>" "//div"`.

This is fast implementation just to make proper benchmarks in InferXPath.

